### PR TITLE
package.json - Don't force a specific react-scripts version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "3.3.0",
+    "react-scripts": "^3.3.0",
     "styled-components": "^5.0.0",
     "use-query-params": "^0.6.0"
   },


### PR DESCRIPTION
Trying to start or build the app with a recent version of Node.js yields
the following error:

  The react-scripts package provided by Create React App requires a
  dependency:

    "babel-eslint": "10.0.3"

  [...], a different version of babel-eslint was detected higher up in
  the tree:

    /opt/gp-former/node_modules/babel-eslint (version: 10.1.0)

Rather than fixing react-scripts version to 3.3.0, allow for any
version compatible with 3.3.0.