### PR TITLE
Dockerfile: Add simple Dockerfile run the app in a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:16
+
+WORKDIR /opt/gp-former
+
+## Install dependencies
+COPY package*.json ./
+RUN npm install
+
+## Copy app sources and build it for production
+COPY public ./public
+COPY src ./src
+RUN yarn build
+
+## Install serve to be used to serve the static site
+RUN npm install -g serve
+
+## Run the app
+EXPOSE 3000
+CMD [ "serve", "-s", "build" ]


### PR DESCRIPTION
Adds a simple Dockerfile that allows to create a docker image based off
Node to run the app.

To build the docker image, simply run:

  docker build . -t <your_image_tag>

Then run the app with:

  docker run -p 3000:3000 -d <your_image_tag>